### PR TITLE
Configurable driver binary copies

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,6 +32,7 @@ The following properties are supported:
 | `driver_platform` | `local` \| `saucelabs` | `local` | Whether the driver should connect to a remote device cloud provider. At the moment, [SauceLabs](https://saucelabs.com/) is the only supported service provider. |
 | `driver_platform_local_headless`| boolean | `false` | When `driver_platform` = `local`, then tests can be run in headless mode. |
 | `driver_custom_args` | string | `None` | Optional custom arguments, that are appended to the browser options, f.i. `incognito` for chrome browsers. Multiple arguments can be comma-separated. |
+| `driver_binary_copy` | boolean | `false` | The driver binary will be copied to a unique temporary file for each parallel process. This is a workaround for parallel selenium driver executions. Use it if you experience errors in parallel test runs. |
 
 ## Appium
 

--- a/gauge_web_app_steps/config/common_config.py
+++ b/gauge_web_app_steps/config/common_config.py
@@ -91,3 +91,7 @@ def is_headless() -> bool:
 def get_custom_args() -> list:
     args_prop = os.environ.get("driver_custom_args", "")
     return [arg.strip() for arg in args_prop.split(",") if arg.strip()]
+
+
+def is_driver_binary_copy() -> bool:
+    return os.environ.get("driver_binary_copy", "false").lower() in ("true", "1")

--- a/gauge_web_app_steps/web_app_steps.py
+++ b/gauge_web_app_steps/web_app_steps.py
@@ -55,21 +55,16 @@ def after_suite_hook() -> None:
 
 @before_spec
 def before_spec_hook(exe_ctx: ExecutionContext) -> None:
-    try:
-        app_ctx = AppContext(exe_ctx)
-        data_store.spec[app_context_key] = app_ctx
-    except Exception as e:
-        print(str(e))
+    app_ctx = AppContext(exe_ctx)
+    data_store.spec[app_context_key] = app_ctx
 
 
 @after_spec
 def after_spec_hook() -> None:
-    try:
-        if driver():
-            print("closing driver")
-            driver().quit()
-    except KeyError:
-        pass  # Error before driver initialization
+    app_ctx: AppContext = data_store.spec.get(app_context_key)
+    if app_ctx is not None and app_ctx.driver is not None:
+        print("closing driver")
+        app_ctx.driver.quit()
 
 
 @before_step


### PR DESCRIPTION
This is a workaround solution for errors that occured lately when executing tests. Locally I could reproduce the errors when Gauge runs with the `--parallel` flag. It was also impossible to run multiple processes of current versions of chrome and gecko-drivers in the terminal from the same binary. Maybe in the future, we will need to remove the support for parallel local tests altogether, but for now this workaround will still allow it.