### PR TITLE
scorecard only on default branch

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -9,9 +9,8 @@ on:
     # Weekly on Saturdays.
     - cron: '30 1 * * 6'
   push:
-    branches: 
-    - dev
-    - master
+    # only default branch is supported
+    branches: [ dev ]
   pull_request:
     branches: [ "*" ]
 


### PR DESCRIPTION
This should fix the CI error: refs/heads/master not supported with push event