### PR TITLE
setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  target-branch: "dependencies"


### PR DESCRIPTION
Depndabot configuration. The bot will open PRs automatically to update dependencies. The target branch will be "dependencies". This way, we can test if the new dependency is messing up something, before merging into default branch.