### PR TITLE
#52 Use device caching with SauceLabs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -60,6 +60,7 @@ The following properties define a connection to the [SauceLabs](https://saucelab
 | `driver_platform_saucelabs_tunnel_name` | string | `None` | If the SauceConnect tunnel is used, the name can be placed here. The Name can be found on the SauceLabs [Tunnel Proxies](https://app.saucelabs.com/tunnels) page. |
 | `driver_platform_saucelabs_test_title` | string | `None` | Test runs can be given a title, so they can be found more easily in the [Test Results](https://app.saucelabs.com/dashboard/tests) or [Builds](https://app.saucelabs.com/dashboard/builds/vdc). |
 | `driver_platform_saucelabs_build` | string | `None` | Test runs can be given a build ID, so they can be found more easily in the [Test Results](https://app.saucelabs.com/dashboard/tests) or [Builds](https://app.saucelabs.com/dashboard/builds/vdc). |
+| `driver_platform_saucelabs_devicecache` | boolean | `false` | Whether real devices should be allocated to a test suit and bypass the device cleaning process in between multiple specifications. A [cacheId](https://docs.saucelabs.com/dev/test-configuration-options/index.html#cacheid) will be assigned automatically. |
 
 The following properties should be set as system variables, rather than Gauge properties:
 

--- a/gauge_web_app_steps/app_context.py
+++ b/gauge_web_app_steps/app_context.py
@@ -21,7 +21,7 @@ class AppContext:
     Context objects are created and kept here.
     """
 
-    def __init__(self, ctx: ExecutionContext = None) -> None:
+    def __init__(self, ctx: ExecutionContext = None, suite_id: str = None) -> None:
         """Initiates objects used in the basic steps."""
         if ctx is None:
             # getgauge's loading mechanism might try to instantiate the class before the lib is ready.
@@ -29,15 +29,15 @@ class AppContext:
         self.report = Report(ctx, config.is_debug_log())
         self._report_driver_options()
         spec : Specification = ctx.specification
-        self.driver = self._create_driver(spec.name)
+        self.driver = self._create_driver(spec.name, suite_id)
         self.image_path = ImagePath(config.get_browser().value, config.is_headless())
         self.images = Images(self.report)
         self.diff_formats = config.get_diff_formats()
         self.mobile = config.get_operating_system().is_mobile()
         self.firefox_page_screenshot_no_scrolling = config.get_browser() == Browser.FIREFOX and config.is_whole_page_screenshot()
 
-    def _create_driver(self, spec_name: str) -> Remote:
-        driver_factory = DriverFactory.create_driver_factory(spec_name)
+    def _create_driver(self, spec_name: str, suite_id: str) -> Remote:
+        driver_factory = DriverFactory.create_driver_factory(spec_name, suite_id)
         return driver_factory.create_driver()
 
     def _report_driver_options(self) -> None:

--- a/gauge_web_app_steps/config/saucelabs_config.py
+++ b/gauge_web_app_steps/config/saucelabs_config.py
@@ -38,6 +38,10 @@ def get_build() -> Optional[str]:
     return os.environ.get("driver_platform_saucelabs_build")
 
 
+def is_device_cached() -> bool:
+    return os.environ.get("driver_platform_saucelabs_devicecache", "false").lower() in ('true', '1')
+
+
 def get_sauce_status_address() -> Optional[str]:
     return os.environ.get("SAUCE_STATUS_ADDRESS")
 

--- a/gauge_web_app_steps/driver/driver_factory.py
+++ b/gauge_web_app_steps/driver/driver_factory.py
@@ -51,9 +51,9 @@ class DriverFactory(ABC):
     """
 
     @staticmethod
-    def create_driver_factory(spec_name: str) -> DriverFactory:
+    def create_driver_factory(spec_name: str, suite_id: str) -> DriverFactory:
         if config.get_platform().is_remote():
-            return SaucelabsDriverFactory(spec_name)
+            return SaucelabsDriverFactory(spec_name, suite_id)
         elif config.get_platform().is_local():
             return LocalDriverFactory()
         else:
@@ -270,8 +270,9 @@ class SaucelabsDriverFactory(DriverFactory):
     This factory creates drivers for the remote Saucelabs environment.
     """
 
-    def __init__(self, spec_name: str) -> None:
+    def __init__(self, spec_name: str, suite_id: str) -> None:
         self.spec_name = spec_name
+        self.suite_id = suite_id
 
     def create_driver(self) -> Remote:
         """Creates and returns a driver for https://saucelabs.com/"""
@@ -396,4 +397,6 @@ class SaucelabsDriverFactory(DriverFactory):
         build = saucelabs_config.get_build()
         if build:
             sauce_options["build"] = build
+        if saucelabs_config.is_device_cached():
+            sauce_options["cacheId"] = self.suite_id
         return sauce_options

--- a/gauge_web_app_steps/web_app_steps.py
+++ b/gauge_web_app_steps/web_app_steps.py
@@ -9,6 +9,7 @@ import re
 import time
 import traceback
 import urllib
+from uuid import uuid4
 
 from itertools import filterfalse
 from typing import Tuple
@@ -37,10 +38,12 @@ from .substitute import substitute
 max_attempts = 12
 basic_auth_key = "_basic_auth"
 error_message_key = "_err_msg"
+suite_id_key = "_suite_id"
 
 @before_suite
 def before_suite_hook() -> None:
     SauceTunnel.start()
+    data_store.suite[suite_id_key] = str(uuid4())
 
 
 @after_suite
@@ -51,7 +54,8 @@ def after_suite_hook() -> None:
 @before_spec
 def before_spec_hook(exe_ctx: ExecutionContext) -> None:
     try:
-        app_ctx = AppContext(exe_ctx)
+        suite_id = data_store.suite[suite_id_key]
+        app_ctx = AppContext(exe_ctx, suite_id)
         data_store.spec[app_context_key] = app_ctx
     except BaseException as e:
         # Gauge swallows some exceptions, so they are handled here

--- a/tests/test_driver/test_driver_factory.py
+++ b/tests/test_driver/test_driver_factory.py
@@ -42,7 +42,7 @@ class TestSaucelabsDriverFactory(unittest.TestCase):
             "driver_operating_system": operating_system.value
         }):
             # act
-            result = SaucelabsDriverFactory("test")._get_sauce_options()
+            result = SaucelabsDriverFactory("test", "suite-id")._get_sauce_options()
             # assert
             self.assertEqual(should_have_appium_version, "appiumVersion" in result,
                 f"result has appium version: {result}, OS: {operating_system}, is mobile: {operating_system.is_mobile()}")
@@ -54,7 +54,7 @@ class TestSaucelabsDriverFactory(unittest.TestCase):
             if tunnel_name is not None: os.environ["driver_platform_saucelabs_tunnel_name"] = tunnel_name
             else: os.environ.pop("driver_platform_saucelabs_tunnel_name", None)
             # act
-            result = SaucelabsDriverFactory("test")._get_sauce_options()
+            result = SaucelabsDriverFactory("test", "suite-id")._get_sauce_options()
             # assert
             self.assertEqual(should_have_tunnel_name, "tunnelName" in result, f"tunnel name was in the result: {result}")
 
@@ -95,9 +95,19 @@ class TestSaucelabsDriverFactory(unittest.TestCase):
         (OperatingSystem.MACOS, "foobar", "foobar"),
     ])
     def test__get_platform_name(self, operating_system: OperatingSystem, operating_system_version: str, expected_value: str):
-        result = SaucelabsDriverFactory("test")._get_platform_name(operating_system, operating_system_version)
+        result = SaucelabsDriverFactory("test", "suite-id")._get_platform_name(operating_system, operating_system_version)
         self.assertEqual(expected_value, result)
 
+    @parameterized.expand([("cache-id", True), ("cache-id", False)])
+    def test__get_sauce_options__cache_id(self, cache_id: str, should_have_device_caching: bool):
+        # arrange
+        with patch.dict('os.environ'):
+            if cache_id is not None: os.environ["driver_platform_saucelabs_devicecache"] = str(should_have_device_caching)
+            else: os.environ.pop("driver_platform_saucelabs_devicecache", None)
+            # act
+            result = SaucelabsDriverFactory("tunnel", cache_id)._get_sauce_options()
+            # assert
+            self.assertEqual(should_have_device_caching, "cacheId" in result, f"cacheId was in the result: {result}")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_driver/test_driver_factory_it.py
+++ b/tests/test_driver/test_driver_factory_it.py
@@ -104,7 +104,7 @@ class TestSaucelabsDriverFactoryIT(unittest.TestCase):
             "driver_operating_system_version": "11"
         }):
             # act
-            result = SaucelabsDriverFactory("test").create_driver()
+            result = SaucelabsDriverFactory("test", "suite-id").create_driver()
             # assert
             self.assertIsNotNone(result)
             self.assertIsInstance(result, Remote)
@@ -121,7 +121,7 @@ class TestSaucelabsDriverFactoryIT(unittest.TestCase):
             "driver_operating_system_version": "11"
         }):
             # act
-            result = SaucelabsDriverFactory("test").create_driver()
+            result = SaucelabsDriverFactory("test", "suite-id").create_driver()
             # assert
             result.get("http://localhost:3000")
             result.find_element(By.CLASS_NAME, "title")


### PR DESCRIPTION
refs https://github.com/IBM/gauge-web-app-steps/issues/52

We create a uuid at the test suite level, that we can reuse over multiple specs and driver instantiations. Then we use that as a cacheId in the sauce:options appium connection.