### PR TITLE
fix: rename hover step to align with other mouse steps

### DIFF
--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -886,25 +886,25 @@ Support
 |:-----:|:--------------:|:----------:|:--------------:|:----------:|
 |   ✔   |       ✔        |     ✔      |       ?        |     ?      |
 
-## Hover over \<by> = \<by_value>
+## Move over \<by> = \<by_value>
 
-> \* Hover over "id" = "search-field"
+> \* Move over "id" = "search-field"
 
-> \* Hover over "xpath" = "//input[@type='text']"
+> \* Move over "xpath" = "//input[@type='text']"
 
-> \* Hover over "link text" = "search link"
+> \* Move over "link text" = "search link"
 
-> \* Hover over "partial link text" = "search"
+> \* Move over "partial link text" = "search"
 
-> \* Hover over "name" = "search-field-name"
+> \* Move over "name" = "search-field-name"
 
-> \* Hover over "tag name" = "input"
+> \* Move over "tag name" = "input"
 
-> \* Hover over "class name" = "search-class"
+> \* Move over "class name" = "search-class"
 
-> \* Hover over "css selector" = "input.searchclass"
+> \* Move over "css selector" = "input.searchclass"
 
-Hover over the specified element.
+Move the mouse over the specified element.
 
 Support
 

--- a/docs/STEPS.md
+++ b/docs/STEPS.md
@@ -52,6 +52,7 @@ The following Gauge steps are implemented in this module:
   - [Move to \<by> = \<by_value>](#move-to-by--by_value)
   - [Move to and center \<by> = \<by_value>](#move-to-and-center-by--by_value)
   - [Move out](#move-out)
+  - [Move over \<by> = \<by_value>](#move-over-by--by_value)
   - [Hover over \<by> = \<by_value>](#hover-over-by--by_value)
   - [Show message in an error case \<error_message>](#show-message-in-an-error-case-error_message)
   - [Scroll \<by> = \<by_value> into view](#scroll-by--by_value-into-view)
@@ -905,6 +906,32 @@ Support
 > \* Move over "css selector" = "input.searchclass"
 
 Move the mouse over the specified element.
+
+Support
+
+|Desktop|Android (Chrome)|iOS (Safari)|Android (Native)|iOS (Native)|
+|:-----:|:--------------:|:----------:|:--------------:|:----------:|
+|   ✔   |       ?        |     ?      |       ?        |     ?      |
+
+## Hover over \<by> = \<by_value>
+
+> \* Hover over "id" = "search-field"
+
+> \* Hover over "xpath" = "//input[@type='text']"
+
+> \* Hover over "link text" = "search link"
+
+> \* Hover over "partial link text" = "search"
+
+> \* Hover over "name" = "search-field-name"
+
+> \* Hover over "tag name" = "input"
+
+> \* Hover over "class name" = "search-class"
+
+> \* Hover over "css selector" = "input.searchclass"
+
+Hover over the specified element. This step is a synonym for the [Move over \<by> = \<by_value>](#move-over-by--by_value) step.
 
 Support
 

--- a/gauge_web_app_steps/web_app_steps.py
+++ b/gauge_web_app_steps/web_app_steps.py
@@ -640,7 +640,7 @@ def move_out_of_view() -> None:
     ActionChains(driver()).move_to_element_with_offset(element, 0, 0).perform()
 
 
-@step("Hover over <by> = <by_value>")
+@step(["Move over <by> = <by_value>", "Hover over <by> = <by_value>"])
 def hover_over(by: str, by_value: str) -> None:
     element = find_element(by, by_value)
     ActionChains(driver()).move_to_element(element).perform()


### PR DESCRIPTION
This PR will rename the Hover step, but still keeps it to be backwards compatible.