### PR TITLE
#62 Add or remove alpha channel from actual screenshot

### DIFF
--- a/tests/test_web_app_steps_it.py
+++ b/tests/test_web_app_steps_it.py
@@ -46,7 +46,8 @@ class TestWebAppStepsIT(unittest.TestCase):
             "GAUGE_PROJECT_ROOT": cls.out,
             "driver_browser": cls.browser,
             "driver_platform_local_headless": "False",
-            "driver_implicit_timeout": "7"
+            "driver_implicit_timeout": "7",
+            "driver_manager_selenium4": "True"
         })
         cls.env_patcher.start()
         before_spec_hook(MagicMock())


### PR DESCRIPTION
This is the first bug fix for issue #62.
There should be a second fix, that will add padding to the expected screenshot, in cases where the actual screenshot is bigger. At the moment this only works the other way around.